### PR TITLE
Cheat menu bugfix & improve

### DIFF
--- a/CJBCheatsMenu/CJBCheatsMenu.csproj
+++ b/CJBCheatsMenu/CJBCheatsMenu.csproj
@@ -65,6 +65,7 @@
     <None Include="i18n\ja.json" />
     <None Include="i18n\ru.json" />
     <None Include="i18n\pt.json" />
+    <None Include="i18n\zh.json" />
     <None Include="i18n\default.json" />
     <None Include="packages.config" />
     <None Include="README.md" />

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -352,17 +352,35 @@ namespace CJBCheatsMenu.Framework
                 if (this.Config.InfiniteStamina)
                     player.stamina = player.MaxStamina;
 
+                // help fishing
                 if (Game1.activeClickableMenu == null && player.CurrentTool is FishingRod rod)
                 {
-                    if (this.Config.ThrowBobberMax)
+                    if (this.Config.AlwaysTreasure)
+                        FishingRod.baseChanceForTreasure = 100;
+
+                    if (this.Config.ThrowBobberMax && rod.isCasting)
                         rod.castingPower = 1.01F;
-                    if (this.Config.InstantBite && rod.isFishing)
+
+                    if (rod.isFishing)
                     {
-                        if (rod.timeUntilFishingBite > 0)
+                        if (this.Config.InstantBite && rod.timeUntilFishingBite > 0 && rod.isFishing)
                             rod.timeUntilFishingBite = 0;
+
+                        if (this.Config.InstantCatch && rod.isNibbling && !rod.hit)
+                            Game1.pressUseToolButton();
+
+                        if (rod.isReeling && rod.fishCaught && Game1.activeClickableMenu is BobberBar bobberMenu)
+                        {
+                            if (this.Config.InstantCatch && rod.isReeling)
+                                helper.Reflection.GetField<float>(bobberMenu, "distanceFromCatching").SetValue(1);
+
+                            if (helper.Reflection.GetField<bool>(bobberMenu, "treasure").GetValue())
+                                helper.Reflection.GetField<bool>(bobberMenu, "treasureCaught").SetValue(true);
+                        }
+
+                        if (this.Config.DurableTackles && rod.attachments[1] != null)
+                            rod.attachments[1].uses.Value = 0;
                     }
-                    if (this.Config.DurableTackles && rod.attachments[1] != null)
-                        rod.attachments[1].uses.Value = 0;
                 }
 
                 if (this.Config.OneHitBreak && player.UsingTool && (player.CurrentTool is Axe || player.CurrentTool is Pickaxe))
@@ -418,28 +436,20 @@ namespace CJBCheatsMenu.Framework
                         friendship.GiftsToday = 0;
                     }
                 }
+
+                // one key kill
+                if (this.Config.OneHitKill)
+                {
+                    foreach (Monster monster in player.currentLocation.characters.OfType<Monster>())
+                    {
+                        if (monster.Health > 1)
+                            monster.Health = 1;
+                    }
+                }
             }
 
             if (this.Config.MaxDailyLuck)
                 Game1.dailyLuck = 0.115d;
-
-            if (this.Config.OneHitKill && Game1.currentLocation != null)
-            {
-                foreach (Monster monster in Game1.currentLocation.characters.OfType<Monster>())
-                    monster.Health = 1;
-            }
-
-            if ((this.Config.InstantCatch || this.Config.AlwaysTreasure) && Game1.activeClickableMenu is BobberBar bobberMenu)
-            {
-                if (this.Config.AlwaysTreasure)
-                    helper.Reflection.GetField<bool>(bobberMenu, "treasure").SetValue(true);
-
-                if (this.Config.InstantCatch)
-                    helper.Reflection.GetField<float>(bobberMenu, "distanceFromCatching").SetValue(1);
-
-                if (helper.Reflection.GetField<bool>(bobberMenu, "treasure").GetValue())
-                    helper.Reflection.GetField<bool>(bobberMenu, "treasureCaught").SetValue(true);
-            }
 
             if (this.Config.InfiniteHay)
             {

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -314,11 +314,8 @@ namespace CJBCheatsMenu.Framework
                 }
 
                 // harvest with sickle
-                if (this.Config.HarvestSickle)
+                if (this.Config.HarvestSickle && (location.IsFarm || location.Name.Contains("Greenhouse")))
                 {
-                    if (!location.IsFarm && !location.Name.Contains("Greenhouse"))
-                        continue;
-
                     foreach (TerrainFeature terrainFeature in location.terrainFeatures.Values)
                     {
                         if (terrainFeature is HoeDirt dirt)

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -194,22 +194,16 @@ namespace CJBCheatsMenu.Framework
 
         public void OneSecondUpdate(GameLocation[] locations)
         {
-            // disable friendship decay
-            if (this.Config.NoFriendshipDecay)
+            // apply friendship changes
+            if (Game1.player != null)
             {
-                if (this.PreviousFriendships.Any())
-                {
-                    foreach (string key in Game1.player.friendshipData.Keys)
-                    {
-                        Friendship friendship = Game1.player.friendshipData[key];
-                        if (this.PreviousFriendships.TryGetValue(key, out int oldPoints) && oldPoints > friendship.Points)
-                            friendship.Points = oldPoints;
-                    }
-                }
-
-                this.PreviousFriendships.Clear();
                 foreach (var pair in Game1.player.friendshipData.FieldDict)
-                    this.PreviousFriendships[pair.Key] = pair.Value.Value.Points;
+                {
+                    int currentPoints = pair.Value.Value.Points;
+                    int oldPoints = 0;
+                    this.PreviousFriendships.TryGetValue(pair.Key, out oldPoints);
+                    this.PreviousFriendships[pair.Key] = pair.Value.Value.Points = this.Config.NoFriendshipDecay && currentPoints < oldPoints ? oldPoints : currentPoints;
+                }
             }
 
             // apply location changes

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -24,10 +24,6 @@ namespace CJBCheatsMenu.Framework
         *********/
         /// <summary>The mod settings.</summary>
         private readonly ModConfig Config;
-
-        /// <summary>The time to maintain if time is frozen.</summary>
-        private int PreviousTime = -1;
-
         /// <summary>The minimum friendship points to maintain for each NPC.</summary>
         private readonly Dictionary<string, int> PreviousFriendships = new Dictionary<string, int>();
 
@@ -160,20 +156,20 @@ namespace CJBCheatsMenu.Framework
 
         public void OnTimeOfDayChanged()
         {
-            GameLocation location = Game1.currentLocation;
-            if (this.PreviousTime == -1 || Game1.timeOfDay == 600)
-                this.PreviousTime = Game1.timeOfDay;
-            else
-            {
-                bool inCave = location is MineShaft || location is FarmCave;
-                bool frozen = (this.Config.FreezeTimeInside && !location.IsOutdoors && !inCave) || (this.Config.FreezeTimeCaves && inCave);
-                frozen = frozen || this.Config.FreezeTime;
-
-                if (frozen)
-                    Game1.timeOfDay = this.PreviousTime;
-                else
-                    this.PreviousTime = Game1.timeOfDay;
-            }
+        //    GameLocation location = Game1.currentLocation;
+        //    if (this.PreviousTime == -1 || Game1.timeOfDay == 600)
+        //        this.PreviousTime = Game1.timeOfDay;
+        //    else
+        //    {
+        //        bool inCave = location is MineShaft || location is FarmCave;
+        //        bool frozen = (this.Config.FreezeTimeInside && !location.IsOutdoors && !inCave) || (this.Config.FreezeTimeCaves && inCave);
+        //        frozen = frozen || this.Config.FreezeTime;
+        //
+        //        if (frozen)
+        //            Game1.timeOfDay = this.PreviousTime;
+        //        else
+        //            this.PreviousTime = Game1.timeOfDay;
+        //    }
         }
 
         public void OnDrawTick(ITranslationHelper i18n)
@@ -448,6 +444,8 @@ namespace CJBCheatsMenu.Framework
                 if (farm != null)
                     farm.piecesOfHay.Value = Utility.numSilos() * 240;
             }
+
+            SetTimeFreezeStatus();
         }
 
         public void OnKeyPress(Keys key)
@@ -484,6 +482,22 @@ namespace CJBCheatsMenu.Framework
             }
 
             return lookup;
+        }
+
+        private void SetTimeFreezeStatus()
+        {
+            GameLocation location = Game1.currentLocation;
+
+            bool frozen = this.Config.FreezeTime;
+
+            if (location != null)
+            {
+	            bool inCave = location is MineShaft || location is FarmCave;
+	            frozen = frozen || (this.Config.FreezeTimeInside && !location.IsOutdoors && !inCave) || (this.Config.FreezeTimeCaves && inCave);
+	        }
+
+            if (frozen)
+                Game1.gameTimeInterval = 0;
         }
     }
 }

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -337,12 +337,9 @@ namespace CJBCheatsMenu.Framework
             {
                 SFarmer player = Game1.player;
 
-                if (this.Config.IncreasedMovement && player.running)
+                if (this.Config.IncreasedMovement && Context.IsPlayerFree && player.running)
                     player.addedSpeed = this.Config.MoveSpeed;
-                else if (!this.Config.IncreasedMovement && player.addedSpeed == this.Config.MoveSpeed)
-                    player.addedSpeed = 0;
-
-                if (player.controller != null)
+                else
                     player.addedSpeed = 0;
 
                 if (Game1.CurrentEvent == null)

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -58,9 +58,9 @@ namespace CJBCheatsMenu.Framework
             Game1.soundBank.PlayCue("thunder");
         }
 
-        public void WaterAllFields(GameLocation[] locations)
+        public void WaterAllFields()
         {
-            foreach (GameLocation location in locations)
+            foreach (GameLocation location in CJB.GetAllLocations())
             {
                 if (!location.IsFarm && !location.Name.Contains("Greenhouse"))
                     continue;

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -208,7 +208,7 @@ namespace CJBCheatsMenu.Framework
 
             // apply location changes
             Farm farm = Game1.getFarm();
-            foreach (GameLocation location in CJB.GetAllLocations())
+            foreach (GameLocation location in locations)
             {
                 // instant buildings
                 if (this.Config.InstantBuild && location is BuildableGameLocation buildableLocation)
@@ -383,7 +383,8 @@ namespace CJBCheatsMenu.Framework
                     }
                 }
 
-                if (this.Config.OneHitBreak && player.UsingTool && (player.CurrentTool is Axe || player.CurrentTool is Pickaxe))
+                // one hit break
+                if (this.Config.OneHitBreak && player.UsingTool && player.CurrentTool is Axe || player.CurrentTool is Pickaxe)
                 {
                     Vector2 tile = new Vector2((int)player.GetToolLocation().X / Game1.tileSize, (int)player.GetToolLocation().Y / Game1.tileSize);
 
@@ -425,9 +426,11 @@ namespace CJBCheatsMenu.Framework
                     }
                 }
 
+                // infinite water can
                 if (this.Config.InfiniteWateringCan && player.CurrentTool is WateringCan can)
-                    helper.Reflection.GetField<int>(can, "waterLeft").SetValue(can.waterCanMax);
+                    can.WaterLeft = can.waterCanMax;
 
+                // give gift every time
                 if (this.Config.AlwaysGiveGift)
                 {
                     foreach (Friendship friendship in player.friendshipData.Values)

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -215,8 +215,10 @@ namespace CJBCheatsMenu.Framework
                 {
                     foreach (Building building in buildableLocation.buildings)
                     {
-                        if (building.daysOfConstructionLeft.Value > 0 || building.daysUntilUpgrade.Value > 0)
-                            building.dayUpdate(1);
+                        if (building.daysOfConstructionLeft.Value > 0)
+                            building.dayUpdate(building.daysOfConstructionLeft.Value);
+                        if (building.daysUntilUpgrade.Value > 0)
+                            building.dayUpdate(building.daysUntilUpgrade.Value);
                     }
                 }
 

--- a/CJBCheatsMenu/Framework/Cheats.cs
+++ b/CJBCheatsMenu/Framework/Cheats.cs
@@ -84,7 +84,10 @@ namespace CJBCheatsMenu.Framework
 
         public void GrowTree()
         {
-            SFarmer player = Game1.player;
+            var player = Game1.player;
+            if (player == null)
+                return;
+            
             int x = (int)player.GetToolLocation().X / Game1.tileSize;
             int y = (int)player.GetToolLocation().Y / Game1.tileSize;
             Vector2 index = new Vector2(x, y);
@@ -110,7 +113,10 @@ namespace CJBCheatsMenu.Framework
 
         public void GrowCrops()
         {
-            SFarmer player = Game1.player;
+            var player = Game1.player;
+            if (player == null)
+                return;
+
             List<Vector2> tiles = new List<Vector2>();
 
             for (int x = -1; x <= 1; x++)
@@ -175,6 +181,9 @@ namespace CJBCheatsMenu.Framework
         public void OnDrawTick(ITranslationHelper i18n)
         {
             GameLocation location = Game1.currentLocation;
+
+            if (location == null)
+                return;
 
             bool inCave = location is MineShaft || location is FarmCave;
             bool frozen = (this.Config.FreezeTimeInside && !location.IsOutdoors && !inCave) || (this.Config.FreezeTimeCaves && inCave);
@@ -285,7 +294,7 @@ namespace CJBCheatsMenu.Framework
                 }
 
                 // autofeed animals
-                if (this.Config.AutoFeed && location is AnimalHouse animalHouse)
+                if (this.Config.AutoFeed && farm != null && location is AnimalHouse animalHouse)
                 {
                     int animalcount = animalHouse.animals.Values.Count();
                     int hayobjects = animalHouse.numberOfObjectsWithName("Hay");

--- a/CJBCheatsMenu/Framework/CheatsOptionsInputListener.cs
+++ b/CJBCheatsMenu/Framework/CheatsOptionsInputListener.cs
@@ -108,7 +108,7 @@ namespace CJBCheatsMenu.Framework
                         break;
                     case 9:
                         Game1.soundBank.PlayCue("glug");
-                        this.Cheats.WaterAllFields(CJB.GetAllLocations().ToArray());
+                        this.Cheats.WaterAllFields();
                         break;
                     case 10:
                         this.Cheats.SetWeatherForNextDay(Game1.weather_sunny);

--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -38,7 +38,7 @@
   "farm.infinite-hay": "无限干草",
   "fishing.title": "钓鱼",
   "fishing.instant-catch": "立即捕抓",
-  "fishing.instant-bite": "立即吃饵",
+  "fishing.instant-bite": "立即咬钩",
   "fishing.always-throw-max-distance": "抛竿总是最远距离",
   "fishing.always-treasure": "必定出现宝箱",
   "fishing.durable-tackles": "钓具不易损毁",


### PR DESCRIPTION
Hi, I fixed some bugs and add some improvements here, may you spend some times to review it?
* change `Game1.timeOfDay` in `TimeEvent.OnTimeOfDayChanged` may repeatedly trigger some other actions, use setting` Game1.gameTimeInterval = 0` in `UpdateEvent.UpdateTick` instead
* reduce some `System.Linq` function using to improve performance
* add some `null` judgements
* `NoFriendshipDecay` should not effect setting friendship points manually
* fixed `Instant bite` may stuck player animations and lose control, `oneKeyKill` may cause monster's healthrepeatly be set to 1 and can never be killed 
* reduce using reflection, add some comments, use param "locations" but not to get from CJB in OneSecondUpdate function
* `Instant building` reduce time to 0 immediately, not 1 day per sec
* modify player addedSpeed should judge Game1.IsPlayerFree
* a little logic fix helping write code
* add chinese translation json to project and fix a translation, help understanding
