### PR TITLE
First time githubber... Simple patch?

### DIFF
--- a/CJBCheatsMenu/i18n/default.json
+++ b/CJBCheatsMenu/i18n/default.json
@@ -24,7 +24,7 @@
   "tools.title": "Tools",
   "tools.infinite-water": "Infinite Water in Can",
   "tools.one-hit-break": "One Hit Break",
-  "tools.harvest-with-sickle": "Harvest With Sickle (no XP gain)",
+  "tools.harvest-with-sickle": "Harvest With Sickle",
   "money.title": "Money",
   "money.add-amount": "Add {{amount}}g",
   "casino-coins.title": "Casino Coins",

--- a/CJBCheatsMenu/i18n/ja.json
+++ b/CJBCheatsMenu/i18n/ja.json
@@ -24,7 +24,7 @@
   "tools.title": "ツール",
   "tools.infinite-water": "ジョウロの水無限",
   "tools.one-hit-break": "1度のアクションで目的達成",
-  "tools.harvest-with-sickle": "カマで収穫（経験値は入らない）",
+  "tools.harvest-with-sickle": "カマで収穫",
   "money.title": "お金",
   "money.add-amount": "増やす {{amount}}g",
   "casino-coins.title": "カジノのコイン",

--- a/CJBCheatsMenu/i18n/pt.json
+++ b/CJBCheatsMenu/i18n/pt.json
@@ -24,7 +24,7 @@
   "tools.title": "Ferramentas",
   "tools.infinite-water": "Água Infinita no Regador",
   "tools.one-hit-break": "Quebrar Tudo Instantaneamente",
-  "tools.harvest-with-sickle": "Colher com a Foice (sem ganho de EXP)",
+  "tools.harvest-with-sickle": "Colher com a Foice",
   "money.title": "Dinheiro",
   "money.add-amount": "Adicionar {{amount}}g",
   "casino-coins.title": "Moedas do Cassino",

--- a/CJBCheatsMenu/i18n/ru.json
+++ b/CJBCheatsMenu/i18n/ru.json
@@ -24,7 +24,7 @@
   "tools.title": "Инструменты",
   "tools.infinite-water": "Бесконечная вода в лейке",
   "tools.one-hit-break": "Разрушение с одного удара",
-  "tools.harvest-with-sickle": "Сбор урожая серпом (без опыта)",
+  "tools.harvest-with-sickle": "Сбор урожая серпом",
   "money.title": "Деньги",
   "money.add-amount": "Добавить {{amount}}з",
   "casino-coins.title": "Клубные монеты",

--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -23,7 +23,7 @@
   "tools.title": "工具",
   "tools.infinite-water": "无限喷壶",
   "tools.one-hit-break": "一拳超人(对物品)",
-  "tools.harvest-with-sickle": "镰刀收获(不会增加经验值)",
+  "tools.harvest-with-sickle": "镰刀收获",
   "money.title": "金钱",
   "money.add-amount": "增加 {{amount}}g",
   "casino-coins.title": "赌场代币",


### PR DESCRIPTION
Just went through and removed '(No XP gain)' from 'Harvest With Sickle' descriptions, since XP gain was fixed in 1.3.27. I am absolutely new. If I'm doing something wrong let me know.
I did make the assumption that the 'no xp gain' disclaimer in parenthesis corresponded to the same parenthesis in the i18n files.