### PR TITLE
Android fixes for CJBCheatsMenu

### DIFF
--- a/CJBCheatsMenu/Framework/CheatsMenu.cs
+++ b/CJBCheatsMenu/Framework/CheatsMenu.cs
@@ -27,11 +27,11 @@ namespace CJBCheatsMenu.Framework
 
         private readonly List<ClickableComponent> OptionSlots = new List<ClickableComponent>();
         private readonly List<OptionsElement> Options = new List<OptionsElement>();
-        private readonly ClickableTextureComponent UpArrow;
-        private readonly ClickableTextureComponent DownArrow;
-        private readonly ClickableTextureComponent Scrollbar;
+        private ClickableTextureComponent UpArrow;
+        private ClickableTextureComponent DownArrow;
+        private ClickableTextureComponent Scrollbar;
         private readonly List<ClickableComponent> Tabs = new List<ClickableComponent>();
-        private readonly ClickableComponent Title;
+        private ClickableComponent Title;
         private const int ItemsPerPage = 10;
 
         private static readonly bool IsAndroid = Constants.TargetPlatform == GamePlatform.Android;
@@ -42,7 +42,7 @@ namespace CJBCheatsMenu.Framework
         private int OptionsSlotHeld = -1;
         private int CurrentItemIndex;
         private bool IsScrolling;
-        private readonly Rectangle ScrollbarRunner;
+        private Rectangle ScrollbarRunner;
         private bool CanClose;
         private bool JustOpened;
 
@@ -53,58 +53,59 @@ namespace CJBCheatsMenu.Framework
         /*********
         ** Public methods
         *********/
-        /// <summary>Construct an instance when no CheatsMenu was previously open.</summary>
-        /// <param name="initialTab">The tab to display by default.</param>
-        /// <param name="cheats">The cheats helper.</param>
-        /// <param name="monitor">Encapsulates monitoring and logging.</param>
-        public CheatsMenu(MenuTab initialTab, CheatManager cheats, IMonitor monitor)
-          : this(initialTab, cheats, monitor, justOpened: true)
-        {}
-
         /// <summary>Construct an instance.</summary>
         /// <param name="initialTab">The tab to display by default.</param>
         /// <param name="cheats">The cheats helper.</param>
         /// <param name="monitor">Encapsulates monitoring and logging.</param>
         /// <param name="justOpened">Whether no CheatsMenu was previously open.</param>
-        protected CheatsMenu(MenuTab initialTab, CheatManager cheats, IMonitor monitor, bool justOpened)
-          : base(Game1.viewport.Width / 2 - (InnerWidth + IClickableMenu.borderWidth * 2 - (int) (Game1.tileSize * 2.4f)) / 2, Game1.viewport.Height / 2 - (InnerHeight + IClickableMenu.borderWidth * 2) / 2, InnerWidth + IClickableMenu.borderWidth * 2, InnerHeight + IClickableMenu.borderWidth * 2, showUpperRightCloseButton: IsAndroid)
+        public CheatsMenu(MenuTab initialTab, CheatManager cheats, IMonitor monitor, bool justOpened = true)
+          : base(0, 0, InnerWidth + IClickableMenu.borderWidth * 2, InnerHeight + IClickableMenu.borderWidth * 2, showUpperRightCloseButton: IsAndroid)
         {
             this.Cheats = cheats;
             this.Monitor = monitor;
             this.JustOpened = justOpened;
-
-            // init UI
-            {
-                var text = cheats.Context.Text;
-                this.Title = new ClickableComponent(new Rectangle(this.xPositionOnScreen + this.width / 2, this.yPositionOnScreen, Game1.tileSize * 4, Game1.tileSize), text.Get("mod-name"));
-                this.CurrentTab = initialTab;
-                {
-                    int i = 0;
-                    int labelX = (int)(this.xPositionOnScreen - Game1.tileSize * 4.8f);
-                    int labelY = (int)(this.yPositionOnScreen + Game1.tileSize * (IsAndroid ? 1.25f : 1.5f));
-                    int labelHeight = (int)(Game1.tileSize * 0.9F);
-
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.PlayerAndTools.ToString(), text.Get("tabs.player-and-tools")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.FarmAndFishing.ToString(), text.Get("tabs.farm-and-fishing")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Skills.ToString(), text.Get("tabs.skills")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Weather.ToString(), text.Get("tabs.weather")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Relationships.ToString(), text.Get("tabs.relationships")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.WarpLocations.ToString(), text.Get("tabs.warp")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Time.ToString(), text.Get("tabs.time")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Advanced.ToString(), text.Get("tabs.advanced")));
-                    this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i, Game1.tileSize * 5, Game1.tileSize), MenuTab.Controls.ToString(), text.Get("tabs.controls")));
-                }
-
-                int scrollbarOffset = Game1.tileSize * (IsAndroid ? 1 : 4) / 16;
-                this.UpArrow = new ClickableTextureComponent("up-arrow", new Rectangle(this.xPositionOnScreen + this.width + scrollbarOffset, this.yPositionOnScreen + Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 459, 11, 12), Game1.pixelZoom);
-                this.DownArrow = new ClickableTextureComponent("down-arrow", new Rectangle(this.xPositionOnScreen + this.width + scrollbarOffset, this.yPositionOnScreen + this.height - Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 472, 11, 12), Game1.pixelZoom);
-                this.Scrollbar = new ClickableTextureComponent("scrollbar", new Rectangle(this.UpArrow.bounds.X + Game1.pixelZoom * 3, this.UpArrow.bounds.Y + this.UpArrow.bounds.Height + Game1.pixelZoom, 6 * Game1.pixelZoom, 10 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(435, 463, 6, 10), Game1.pixelZoom);
-                this.ScrollbarRunner = new Rectangle(this.Scrollbar.bounds.X, this.UpArrow.bounds.Y + this.UpArrow.bounds.Height + Game1.pixelZoom, this.Scrollbar.bounds.Width, this.height - Game1.tileSize * 2 - this.UpArrow.bounds.Height - Game1.pixelZoom * 2);
-
-                for (int i = 0; i < CheatsMenu.ItemsPerPage; i++)
-                    this.OptionSlots.Add(new ClickableComponent(new Rectangle(this.xPositionOnScreen + Game1.tileSize / 4, this.yPositionOnScreen + Game1.tileSize * 5 / 4 + Game1.pixelZoom + i * ((this.height - Game1.tileSize * 2) / CheatsMenu.ItemsPerPage), this.width - Game1.tileSize / 2, (this.height - Game1.tileSize * 2) / CheatsMenu.ItemsPerPage + Game1.pixelZoom), string.Concat(i)));
-            }
+            this.CurrentTab = initialTab;
+            this.ResetComponents();
             this.SetOptions();
+        }
+
+        /// <summary>Initialize or reinitialize the UI components.</summary>
+        private void ResetComponents()
+        {
+            this.xPositionOnScreen = Game1.viewport.Width / 2 - (InnerWidth + IClickableMenu.borderWidth * 2 - (int) (Game1.tileSize * 2.4f)) / 2;
+            this.yPositionOnScreen = Game1.viewport.Height / 2 - (InnerHeight + IClickableMenu.borderWidth * 2) / 2;
+            if (IsAndroid)
+                initializeUpperRightCloseButton();
+
+            var text = this.Cheats.Context.Text;
+            this.Title = new ClickableComponent(new Rectangle(this.xPositionOnScreen + this.width / 2, this.yPositionOnScreen, Game1.tileSize * 4, Game1.tileSize), text.Get("mod-name"));
+            this.Tabs.Clear();
+            {
+                int i = 0;
+                int labelX = (int)(this.xPositionOnScreen - Game1.tileSize * 4.8f);
+                int labelY = (int)(this.yPositionOnScreen + Game1.tileSize * (IsAndroid ? 1.25f : 1.5f));
+                int labelHeight = (int)(Game1.tileSize * 0.9F);
+
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.PlayerAndTools.ToString(), text.Get("tabs.player-and-tools")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.FarmAndFishing.ToString(), text.Get("tabs.farm-and-fishing")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Skills.ToString(), text.Get("tabs.skills")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Weather.ToString(), text.Get("tabs.weather")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Relationships.ToString(), text.Get("tabs.relationships")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.WarpLocations.ToString(), text.Get("tabs.warp")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Time.ToString(), text.Get("tabs.time")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.Advanced.ToString(), text.Get("tabs.advanced")));
+                this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i, Game1.tileSize * 5, Game1.tileSize), MenuTab.Controls.ToString(), text.Get("tabs.controls")));
+            }
+
+            int scrollbarOffset = Game1.tileSize * (IsAndroid ? 1 : 4) / 16;
+            this.UpArrow = new ClickableTextureComponent("up-arrow", new Rectangle(this.xPositionOnScreen + this.width + scrollbarOffset, this.yPositionOnScreen + Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 459, 11, 12), Game1.pixelZoom);
+            this.DownArrow = new ClickableTextureComponent("down-arrow", new Rectangle(this.xPositionOnScreen + this.width + scrollbarOffset, this.yPositionOnScreen + this.height - Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 472, 11, 12), Game1.pixelZoom);
+            this.Scrollbar = new ClickableTextureComponent("scrollbar", new Rectangle(this.UpArrow.bounds.X + Game1.pixelZoom * 3, this.UpArrow.bounds.Y + this.UpArrow.bounds.Height + Game1.pixelZoom, 6 * Game1.pixelZoom, 10 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(435, 463, 6, 10), Game1.pixelZoom);
+            this.ScrollbarRunner = new Rectangle(this.Scrollbar.bounds.X, this.UpArrow.bounds.Y + this.UpArrow.bounds.Height + Game1.pixelZoom, this.Scrollbar.bounds.Width, this.height - Game1.tileSize * 2 - this.UpArrow.bounds.Height - Game1.pixelZoom * 2);
+
+            this.OptionSlots.Clear();
+            for (int i = 0; i < CheatsMenu.ItemsPerPage; i++)
+                this.OptionSlots.Add(new ClickableComponent(new Rectangle(this.xPositionOnScreen + Game1.tileSize / 4, this.yPositionOnScreen + Game1.tileSize * 5 / 4 + Game1.pixelZoom + i * ((this.height - Game1.tileSize * 2) / CheatsMenu.ItemsPerPage), this.width - Game1.tileSize / 2, (this.height - Game1.tileSize * 2) / CheatsMenu.ItemsPerPage + Game1.pixelZoom), string.Concat(i)));
         }
 
         /// <summary>Whether controller-style menus should be disabled for this menu.</summary>
@@ -319,9 +320,9 @@ namespace CJBCheatsMenu.Framework
             if (!Game1.options.hardwareCursor && !IsAndroid)
                 spriteBatch.Draw(Game1.mouseCursors, new Vector2(Game1.getOldMouseX(), Game1.getOldMouseY()), Game1.getSourceRectForStandardTileSheet(Game1.mouseCursors, Game1.options.gamepadControls ? 44 : 0, 16, 16), Color.White, 0f, Vector2.Zero, Game1.pixelZoom + Game1.dialogueButtonScale / 150f, SpriteEffects.None, 1f);
 
-            // This one weird trick fixes Android pinch-zoom scaling issues.
+            // Reinitialize the UI to fix Android pinch-zoom scaling issues.
             if (this.JustOpened && IsAndroid)
-                Game1.activeClickableMenu = new CheatsMenu(this.CurrentTab, this.Cheats, this.Monitor, false);
+                ResetComponents();
         }
 
 

--- a/CJBCheatsMenu/Framework/CheatsMenu.cs
+++ b/CJBCheatsMenu/Framework/CheatsMenu.cs
@@ -34,12 +34,17 @@ namespace CJBCheatsMenu.Framework
         private readonly ClickableComponent Title;
         private const int ItemsPerPage = 10;
 
+        private static readonly bool IsAndroid = Constants.TargetPlatform == GamePlatform.Android;
+        private static readonly int InnerWidth = IsAndroid ? 750 : 800;
+        private static readonly int InnerHeight = IsAndroid ? 550 : 600;
+
         private string HoverText = "";
         private int OptionsSlotHeld = -1;
         private int CurrentItemIndex;
         private bool IsScrolling;
         private readonly Rectangle ScrollbarRunner;
         private bool CanClose;
+        private bool JustOpened;
 
         /// <summary>The currently open tab.</summary>
         private readonly MenuTab CurrentTab;
@@ -48,15 +53,25 @@ namespace CJBCheatsMenu.Framework
         /*********
         ** Public methods
         *********/
-        /// <summary>Construct an instance.</summary>
+        /// <summary>Construct an instance when no CheatsMenu was previously open.</summary>
         /// <param name="initialTab">The tab to display by default.</param>
         /// <param name="cheats">The cheats helper.</param>
         /// <param name="monitor">Encapsulates monitoring and logging.</param>
         public CheatsMenu(MenuTab initialTab, CheatManager cheats, IMonitor monitor)
-          : base(Game1.viewport.Width / 2 - (600 + IClickableMenu.borderWidth * 2) / 2, Game1.viewport.Height / 2 - (600 + IClickableMenu.borderWidth * 2) / 2, 800 + IClickableMenu.borderWidth * 2, 600 + IClickableMenu.borderWidth * 2)
+          : this(initialTab, cheats, monitor, justOpened: true)
+        {}
+
+        /// <summary>Construct an instance.</summary>
+        /// <param name="initialTab">The tab to display by default.</param>
+        /// <param name="cheats">The cheats helper.</param>
+        /// <param name="monitor">Encapsulates monitoring and logging.</param>
+        /// <param name="justOpened">Whether no CheatsMenu was previously open.</param>
+        protected CheatsMenu(MenuTab initialTab, CheatManager cheats, IMonitor monitor, bool justOpened)
+          : base(Game1.viewport.Width / 2 - (InnerWidth + IClickableMenu.borderWidth * 2 - (int) (Game1.tileSize * 2.4f)) / 2, Game1.viewport.Height / 2 - (InnerHeight + IClickableMenu.borderWidth * 2) / 2, InnerWidth + IClickableMenu.borderWidth * 2, InnerHeight + IClickableMenu.borderWidth * 2, showUpperRightCloseButton: IsAndroid)
         {
             this.Cheats = cheats;
             this.Monitor = monitor;
+            this.JustOpened = justOpened;
 
             // init UI
             {
@@ -66,7 +81,7 @@ namespace CJBCheatsMenu.Framework
                 {
                     int i = 0;
                     int labelX = (int)(this.xPositionOnScreen - Game1.tileSize * 4.8f);
-                    int labelY = (int)(this.yPositionOnScreen + Game1.tileSize * 1.5f);
+                    int labelY = (int)(this.yPositionOnScreen + Game1.tileSize * (IsAndroid ? 1.25f : 1.5f));
                     int labelHeight = (int)(Game1.tileSize * 0.9F);
 
                     this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i++, Game1.tileSize * 5, Game1.tileSize), MenuTab.PlayerAndTools.ToString(), text.Get("tabs.player-and-tools")));
@@ -80,8 +95,9 @@ namespace CJBCheatsMenu.Framework
                     this.Tabs.Add(new ClickableComponent(new Rectangle(labelX, labelY + labelHeight * i, Game1.tileSize * 5, Game1.tileSize), MenuTab.Controls.ToString(), text.Get("tabs.controls")));
                 }
 
-                this.UpArrow = new ClickableTextureComponent("up-arrow", new Rectangle(this.xPositionOnScreen + this.width + Game1.tileSize / 4, this.yPositionOnScreen + Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 459, 11, 12), Game1.pixelZoom);
-                this.DownArrow = new ClickableTextureComponent("down-arrow", new Rectangle(this.xPositionOnScreen + this.width + Game1.tileSize / 4, this.yPositionOnScreen + this.height - Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 472, 11, 12), Game1.pixelZoom);
+                int scrollbarOffset = Game1.tileSize * (IsAndroid ? 1 : 4) / 16;
+                this.UpArrow = new ClickableTextureComponent("up-arrow", new Rectangle(this.xPositionOnScreen + this.width + scrollbarOffset, this.yPositionOnScreen + Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 459, 11, 12), Game1.pixelZoom);
+                this.DownArrow = new ClickableTextureComponent("down-arrow", new Rectangle(this.xPositionOnScreen + this.width + scrollbarOffset, this.yPositionOnScreen + this.height - Game1.tileSize, 11 * Game1.pixelZoom, 12 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(421, 472, 11, 12), Game1.pixelZoom);
                 this.Scrollbar = new ClickableTextureComponent("scrollbar", new Rectangle(this.UpArrow.bounds.X + Game1.pixelZoom * 3, this.UpArrow.bounds.Y + this.UpArrow.bounds.Height + Game1.pixelZoom, 6 * Game1.pixelZoom, 10 * Game1.pixelZoom), "", "", Game1.mouseCursors, new Rectangle(435, 463, 6, 10), Game1.pixelZoom);
                 this.ScrollbarRunner = new Rectangle(this.Scrollbar.bounds.X, this.UpArrow.bounds.Y + this.UpArrow.bounds.Height + Game1.pixelZoom, this.Scrollbar.bounds.Width, this.height - Game1.tileSize * 2 - this.UpArrow.bounds.Height - Game1.pixelZoom * 2);
 
@@ -109,7 +125,7 @@ namespace CJBCheatsMenu.Framework
             {
                 int num = this.Scrollbar.bounds.Y;
                 this.Scrollbar.bounds.Y = Math.Min(this.yPositionOnScreen + this.height - Game1.tileSize - Game1.pixelZoom * 3 - this.Scrollbar.bounds.Height, Math.Max(y, this.yPositionOnScreen + this.UpArrow.bounds.Height + Game1.pixelZoom * 5));
-                this.CurrentItemIndex = Math.Min(this.Options.Count - CheatsMenu.ItemsPerPage, Math.Max(0, (int)(this.Options.Count * (double)((y - this.ScrollbarRunner.Y) / (float)this.ScrollbarRunner.Height))));
+                this.CurrentItemIndex = Math.Min(this.Options.Count - CheatsMenu.ItemsPerPage, Math.Max(0, (int)Math.Round((this.Options.Count - CheatsMenu.ItemsPerPage) * (double)((y - this.ScrollbarRunner.Y) / (float)this.ScrollbarRunner.Height))));
                 this.SetScrollBarToCurrentIndex();
                 if (num == this.Scrollbar.bounds.Y)
                     return;
@@ -163,7 +179,7 @@ namespace CJBCheatsMenu.Framework
 
                 // open menu with new index
                 MenuTab tabID = this.GetTabID(this.Tabs[index]);
-                Game1.activeClickableMenu = new CheatsMenu(tabID, this.Cheats, this.Monitor);
+                Game1.activeClickableMenu = new CheatsMenu(tabID, this.Cheats, this.Monitor, false);
             }
         }
 
@@ -206,6 +222,8 @@ namespace CJBCheatsMenu.Framework
         {
             if (GameMenu.forcePreventClose)
                 return;
+            base.receiveLeftClick(x, y, playSound);
+
             if (this.DownArrow.containsPoint(x, y) && this.CurrentItemIndex < Math.Max(0, this.Options.Count - CheatsMenu.ItemsPerPage))
             {
                 this.DownArrowPressed();
@@ -240,7 +258,7 @@ namespace CJBCheatsMenu.Framework
                 if (tab.bounds.Contains(x, y))
                 {
                     MenuTab tabID = this.GetTabID(tab);
-                    Game1.activeClickableMenu = new CheatsMenu(tabID, this.Cheats, this.Monitor);
+                    Game1.activeClickableMenu = new CheatsMenu(tabID, this.Cheats, this.Monitor, false);
                     break;
                 }
             }
@@ -265,6 +283,7 @@ namespace CJBCheatsMenu.Framework
         {
             if (!Game1.options.showMenuBackground)
                 spriteBatch.Draw(Game1.fadeToBlackRect, Game1.graphics.GraphicsDevice.Viewport.Bounds, Color.Black * 0.4f);
+            base.draw(spriteBatch);
 
             Game1.drawDialogueBox(this.xPositionOnScreen, this.yPositionOnScreen, this.width, this.height, false, true);
             CommonHelper.DrawTextBox(this.Title.bounds.X, this.Title.bounds.Y, Game1.dialogueFont, this.Title.name, 1);
@@ -297,8 +316,12 @@ namespace CJBCheatsMenu.Framework
             if (this.HoverText != "")
                 IClickableMenu.drawHoverText(spriteBatch, this.HoverText, Game1.smallFont);
 
-            if (!Game1.options.hardwareCursor)
+            if (!Game1.options.hardwareCursor && !IsAndroid)
                 spriteBatch.Draw(Game1.mouseCursors, new Vector2(Game1.getOldMouseX(), Game1.getOldMouseY()), Game1.getSourceRectForStandardTileSheet(Game1.mouseCursors, Game1.options.gamepadControls ? 44 : 0, 16, 16), Color.White, 0f, Vector2.Zero, Game1.pixelZoom + Game1.dialogueButtonScale / 150f, SpriteEffects.None, 1f);
+
+            // This one weird trick fixes Android pinch-zoom scaling issues.
+            if (this.JustOpened && IsAndroid)
+                Game1.activeClickableMenu = new CheatsMenu(this.CurrentTab, this.Cheats, this.Monitor, false);
         }
 
 
@@ -468,6 +491,8 @@ namespace CJBCheatsMenu.Framework
 
                 case MenuTab.Controls:
                     this.AddTitle($"{text.Get("controls.title")}:");
+                    if (IsAndroid)
+                        this.Options.AddRange(this.GetDescriptionElements(text.Get("controls.android")));
                     this.AddOptions(
                         new CheatsOptionsKeyListener(
                             label: text.Get("controls.open-menu"),

--- a/CJBCheatsMenu/Framework/Components/CheatsOptionsCheckbox.cs
+++ b/CJBCheatsMenu/Framework/Components/CheatsOptionsCheckbox.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -56,7 +57,10 @@ namespace CJBCheatsMenu.Framework.Components
         public override void draw(SpriteBatch spriteBatch, int slotX, int slotY)
         {
             spriteBatch.Draw(Game1.mouseCursors, new Vector2(slotX + this.bounds.X, slotY + this.bounds.Y), this.IsChecked ? OptionsCheckbox.sourceRectChecked : OptionsCheckbox.sourceRectUnchecked, Color.White * (this.greyedOut ? 0.33f : 1f), 0.0f, Vector2.Zero, Game1.pixelZoom, SpriteEffects.None, 0.4f);
-            base.draw(spriteBatch, slotX, slotY);
+
+            // Android port doesn't consider the control width, so we do so here.
+            int adjustX = (Constants.TargetPlatform == GamePlatform.Android) ? bounds.Width + 8 : 0;
+            base.draw(spriteBatch, slotX + adjustX, slotY);
         }
     }
 }

--- a/CJBCheatsMenu/Framework/Components/CheatsOptionsKeyListener.cs
+++ b/CJBCheatsMenu/Framework/Components/CheatsOptionsKeyListener.cs
@@ -61,7 +61,7 @@ namespace CJBCheatsMenu.Framework.Components
         /// <param name="y">The cursor's Y pixel position.</param>
         public override void receiveLeftClick(int x, int y)
         {
-            if (this.greyedOut || this.Listening || !this.SetButtonBounds.Contains(x, y))
+            if (this.greyedOut || this.Listening || !this.SetButtonBounds.Contains(x, y) || Constants.TargetPlatform == GamePlatform.Android)
                 return;
 
             this.Listening = true;
@@ -100,7 +100,8 @@ namespace CJBCheatsMenu.Framework.Components
         public override void draw(SpriteBatch spriteBatch, int slotX, int slotY)
         {
             Utility.drawTextWithShadow(spriteBatch, $"{this.label}: {this.Value}", Game1.dialogueFont, new Vector2(this.bounds.X + slotX, this.bounds.Y + slotY), this.greyedOut ? Game1.textColor * 0.33f : Game1.textColor, 1f, 0.15f);
-            Utility.drawWithShadow(spriteBatch, Game1.mouseCursors, new Vector2(this.SetButtonBounds.X + slotX, this.SetButtonBounds.Y + slotY), this.SetButtonSprite, Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom, false, 0.15f);
+            if (Constants.TargetPlatform != GamePlatform.Android)
+                Utility.drawWithShadow(spriteBatch, Game1.mouseCursors, new Vector2(this.SetButtonBounds.X + slotX, this.SetButtonBounds.Y + slotY), this.SetButtonSprite, Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom, false, 0.15f);
 
             if (this.Listening)
             {

--- a/CJBCheatsMenu/Framework/Components/CheatsOptionsNPCSlider.cs
+++ b/CJBCheatsMenu/Framework/Components/CheatsOptionsNPCSlider.cs
@@ -2,6 +2,7 @@ using System;
 using CJB.Common;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -87,7 +88,9 @@ namespace CJBCheatsMenu.Framework.Components
         /// <param name="slotY">The Y position at which to draw, relative to the bounds.</param>
         public override void draw(SpriteBatch spriteBatch, int slotX, int slotY)
         {
-            base.draw(spriteBatch, slotX, slotY);
+            // Android port doesn't consider the control width, so we do so here.
+            int adjustX = (Constants.TargetPlatform == GamePlatform.Android) ? bounds.Width + 8 : 0;
+            base.draw(spriteBatch, slotX + adjustX, slotY);
 
             Color tint = this.greyedOut ? (Color.White * 0.5f) : Color.White;
 

--- a/CJBCheatsMenu/Framework/Components/CheatsOptionsSlider.cs
+++ b/CJBCheatsMenu/Framework/Components/CheatsOptionsSlider.cs
@@ -2,6 +2,7 @@ using System;
 using CJB.Common;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -110,7 +111,9 @@ namespace CJBCheatsMenu.Framework.Components
             this.label = $"{this.Label}: {this.Format(this.Value)}";
             this.greyedOut = this.IsDisabled();
 
-            base.draw(spriteBatch, slotX, slotY);
+            // Android port doesn't consider the control width, so we do so here.
+            int adjustX = (Constants.TargetPlatform == GamePlatform.Android) ? bounds.Width + 8 : 0;
+            base.draw(spriteBatch, slotX + adjustX, slotY);
 
             int sliderOffsetX = CommonHelper.GetValueAtPosition(this.ValuePosition, 0, this.PixelWidth);
             IClickableMenu.drawTextureBox(spriteBatch, Game1.mouseCursors, OptionsSlider.sliderBGSource, slotX + this.bounds.X, slotY + this.bounds.Y, this.bounds.Width, this.bounds.Height, Color.White, Game1.pixelZoom, false);

--- a/CJBCheatsMenu/i18n/de.json
+++ b/CJBCheatsMenu/i18n/de.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Steuerungen",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "Menü öffnen",
     "controls.freeze-time": "Zeit stoppen",
     "controls.grow-tree": "Baum wachsen lassen",

--- a/CJBCheatsMenu/i18n/de.json
+++ b/CJBCheatsMenu/i18n/de.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Steuerungen",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "Menü öffnen",
     "controls.freeze-time": "Zeit stoppen",
     "controls.grow-tree": "Baum wachsen lassen",

--- a/CJBCheatsMenu/i18n/default.json
+++ b/CJBCheatsMenu/i18n/default.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Controls",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.",
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.",
     "controls.open-menu": "Open Menu",
     "controls.freeze-time": "Freeze Time",
     "controls.grow-tree": "Grow Tree",

--- a/CJBCheatsMenu/i18n/default.json
+++ b/CJBCheatsMenu/i18n/default.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Controls",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.",
     "controls.open-menu": "Open Menu",
     "controls.freeze-time": "Freeze Time",
     "controls.grow-tree": "Grow Tree",

--- a/CJBCheatsMenu/i18n/es.json
+++ b/CJBCheatsMenu/i18n/es.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Controles",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "Abrir Menu",
     "controls.freeze-time": "Congelar Tiempo",
     "controls.grow-tree": "Cultivar Árbol",

--- a/CJBCheatsMenu/i18n/es.json
+++ b/CJBCheatsMenu/i18n/es.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Controles",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "Abrir Menu",
     "controls.freeze-time": "Congelar Tiempo",
     "controls.grow-tree": "Cultivar Árbol",

--- a/CJBCheatsMenu/i18n/fr.json
+++ b/CJBCheatsMenu/i18n/fr.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Contrôles",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "Ouvrir ce menu",
     "controls.freeze-time": "Arrêter le temps",
     "controls.grow-tree": "Faire pousser les arbres",

--- a/CJBCheatsMenu/i18n/fr.json
+++ b/CJBCheatsMenu/i18n/fr.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Contrôles",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "Ouvrir ce menu",
     "controls.freeze-time": "Arrêter le temps",
     "controls.grow-tree": "Faire pousser les arbres",

--- a/CJBCheatsMenu/i18n/hu.json
+++ b/CJBCheatsMenu/i18n/hu.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Irányítás",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "Menu Megnyitása",
     "controls.freeze-time": "Idő Megállítása",
     "controls.grow-tree": "Fák megnövesztése",

--- a/CJBCheatsMenu/i18n/hu.json
+++ b/CJBCheatsMenu/i18n/hu.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Irányítás",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "Menu Megnyitása",
     "controls.freeze-time": "Idő Megállítása",
     "controls.grow-tree": "Fák megnövesztése",

--- a/CJBCheatsMenu/i18n/ja.json
+++ b/CJBCheatsMenu/i18n/ja.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "コントロール",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "チートメニューを表示",
     "controls.freeze-time": "時間を止める",
     "controls.grow-tree": "果樹が生長する",

--- a/CJBCheatsMenu/i18n/ja.json
+++ b/CJBCheatsMenu/i18n/ja.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "コントロール",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "チートメニューを表示",
     "controls.freeze-time": "時間を止める",
     "controls.grow-tree": "果樹が生長する",

--- a/CJBCheatsMenu/i18n/ko.json
+++ b/CJBCheatsMenu/i18n/ko.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "조작키",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "메뉴 열기",
     "controls.freeze-time": "시간 정지",
     "controls.grow-tree": "나무 자라게하기",

--- a/CJBCheatsMenu/i18n/ko.json
+++ b/CJBCheatsMenu/i18n/ko.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "조작키",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "메뉴 열기",
     "controls.freeze-time": "시간 정지",
     "controls.grow-tree": "나무 자라게하기",

--- a/CJBCheatsMenu/i18n/pt.json
+++ b/CJBCheatsMenu/i18n/pt.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Controles",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "Abrir menu",
     "controls.freeze-time": "Parar o tempo",
     "controls.grow-tree": "Crescer árvores",

--- a/CJBCheatsMenu/i18n/pt.json
+++ b/CJBCheatsMenu/i18n/pt.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Controles",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "Abrir menu",
     "controls.freeze-time": "Parar o tempo",
     "controls.grow-tree": "Crescer árvores",

--- a/CJBCheatsMenu/i18n/ru.json
+++ b/CJBCheatsMenu/i18n/ru.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Управление",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "Открыть меню",
     "controls.freeze-time": "Остановить время",
     "controls.grow-tree": "Вырастить деревья",

--- a/CJBCheatsMenu/i18n/ru.json
+++ b/CJBCheatsMenu/i18n/ru.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "Управление",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "Открыть меню",
     "controls.freeze-time": "Остановить время",
     "controls.grow-tree": "Вырастить деревья",

--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -236,6 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "按键绑定",
+    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
     "controls.open-menu": "打开菜单",
     "controls.freeze-time": "冻结时间",
     "controls.grow-tree": "树木立即长大",

--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -236,7 +236,7 @@
     ** Controls tab
     *********/
     "controls.title": "按键绑定",
-    "controls.android": "The virtual keys can be chosen by editing this mod's config file.", // TODO
+    "controls.android": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.", // TODO
     "controls.open-menu": "打开菜单",
     "controls.freeze-time": "冻结时间",
     "controls.grow-tree": "树木立即长大",


### PR DESCRIPTION
- FreezeTimeCheat: fit around Virtual Keyboard toggle; hide when menu up
- Checkbox, NPCSlider, Slider: work around Android oddity in IClickableMenu.draw
- KeyListener: don't show button on Android
- CheatsMenu: show close button on Android
- CheatsMenu: reduce size and padding on Android
- CheatsMenu: hack around Android pinch-zoom scaling issue
- CheatsMenu.leftClickHeld: fix scrollbar click calculation (cross-platform)
- i18n: add "controls.android"