### PR TITLE
add date cheats: year, season, day

### DIFF
--- a/CJBCheatsMenu/Framework/CheatManager.cs
+++ b/CJBCheatsMenu/Framework/CheatManager.cs
@@ -164,13 +164,22 @@ namespace CJBCheatsMenu.Framework
         public ICheat Warps { get; }
 
         /****
-        ** Time
+        ** Time & Date
         ****/
         /// <summary>Stops the passage of time.</summary>
         public ICheat FreezeTime { get; } = new FreezeTimeCheat();
 
         /// <summary>Sets the current time.</summary>
         public ICheat SetTime { get; } = new SetTimeCheat();
+
+        /// <summary>Sets the current year.</summary>
+        public ICheat SetYear { get; } = new SetYearCheat();
+
+        /// <summary>Sets the current season.</summary>
+        public ICheat SetSeason { get; } = new SetSeasonCheat();
+
+        /// <summary>Sets the current day of the season.</summary>
+        public ICheat SetDay { get; } = new SetDayCheat();
 
         /****
         ** Advanced

--- a/CJBCheatsMenu/Framework/CheatManager.cs
+++ b/CJBCheatsMenu/Framework/CheatManager.cs
@@ -164,7 +164,7 @@ namespace CJBCheatsMenu.Framework
         public ICheat Warps { get; }
 
         /****
-        ** Time & Date
+        ** Time
         ****/
         /// <summary>Stops the passage of time.</summary>
         public ICheat FreezeTime { get; } = new FreezeTimeCheat();

--- a/CJBCheatsMenu/Framework/Cheats/Time/BaseDateCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/BaseDateCheat.cs
@@ -1,0 +1,34 @@
+using StardewModdingAPI.Utilities;
+using StardewValley;
+
+namespace CJBCheatsMenu.Framework.Cheats.Time
+{
+    /// <summary>The base implementation for classes which change the date.</summary>
+    internal abstract class BaseDateCheat : BaseCheat
+    {
+        /*********
+        ** Protected methods
+        *********/
+        /// <summary>Safely transition to the given day.</summary>
+        /// <param name="day">The day of month.</param>
+        /// <param name="season">The season.</param>
+        /// <param name="year">The year.</param>
+        protected void SafelySetDate(int day, string season, int year)
+        {
+            // update raw values
+            bool seasonChanged = season != Game1.currentSeason;
+            Game1.dayOfMonth = day;
+            Game1.currentSeason = season;
+            Game1.year = year;
+
+            // update derived state
+            Game1.stats.DaysPlayed = (uint)SDate.Now().DaysSinceStart;
+            if (Game1.IsMasterGame)
+                Game1.netWorldState.Value.UpdateFromGame1();
+
+            // update seasonal textures
+            if (seasonChanged)
+                Game1.setGraphicsForSeason();
+        }
+    }
+}

--- a/CJBCheatsMenu/Framework/Cheats/Time/SetDayCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/SetDayCheat.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using CJBCheatsMenu.Framework.Components;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+using StardewValley.Menus;
+
+namespace CJBCheatsMenu.Framework.Cheats.Time
+{
+    /// <summary>A cheat which sets the current day.</summary>
+    internal class SetDayCheat : BaseCheat
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Get the config UI fields to show in the cheats menu.</summary>
+        /// <param name="context">The cheat context.</param>
+        public override IEnumerable<OptionsElement> GetFields(CheatContext context)
+        {
+            yield return new CheatsOptionsSlider(
+                label: I18n.Date_Day(),
+                value: Game1.dayOfMonth,
+                minValue: 1,
+                maxValue: 28,
+                setValue: this.SafelySetDay,
+                width: 100
+            );
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Safely transition to the given day.</summary>
+        /// <param name="day">The day.</param>
+        private void SafelySetDay(int day)
+        {
+            Game1.dayOfMonth = day;
+            Game1.stats.DaysPlayed = (uint)SDate.Now().DaysSinceStart;
+            if (Game1.IsMasterGame)
+                Game1.netWorldState.Value.UpdateFromGame1();
+        }
+    }
+}

--- a/CJBCheatsMenu/Framework/Cheats/Time/SetDayCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/SetDayCheat.cs
@@ -1,13 +1,12 @@
 using System.Collections.Generic;
 using CJBCheatsMenu.Framework.Components;
-using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
 
 namespace CJBCheatsMenu.Framework.Cheats.Time
 {
     /// <summary>A cheat which sets the current day.</summary>
-    internal class SetDayCheat : BaseCheat
+    internal class SetDayCheat : BaseDateCheat
     {
         /*********
         ** Public methods
@@ -34,10 +33,7 @@ namespace CJBCheatsMenu.Framework.Cheats.Time
         /// <param name="day">The day.</param>
         private void SafelySetDay(int day)
         {
-            Game1.dayOfMonth = day;
-            Game1.stats.DaysPlayed = (uint)SDate.Now().DaysSinceStart;
-            if (Game1.IsMasterGame)
-                Game1.netWorldState.Value.UpdateFromGame1();
+            this.SafelySetDate(day, Game1.currentSeason, Game1.year);
         }
     }
 }

--- a/CJBCheatsMenu/Framework/Cheats/Time/SetSeasonCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/SetSeasonCheat.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using CJBCheatsMenu.Framework.Components;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+using StardewValley.Menus;
+
+namespace CJBCheatsMenu.Framework.Cheats.Time
+{
+    /// <summary>A cheat which sets the current season.</summary>
+    internal class SetSeasonCheat : BaseCheat
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Get the config UI fields to show in the cheats menu.</summary>
+        /// <param name="context">The cheat context.</param>
+        public override IEnumerable<OptionsElement> GetFields(CheatContext context)
+        {
+            yield return new CheatsOptionsSlider(
+                label: I18n.Date_Season(),
+                value: Utility.getSeasonNumber(Game1.currentSeason),
+                minValue: 0,
+                maxValue: 3,
+                setValue: this.SafelySetSeason,
+                width: 100,
+                format: value => Utility.getSeasonNameFromNumber(value)
+            );
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Safely transition to the given season.</summary>
+        /// <param name="season">The season.</param>
+        private void SafelySetSeason(int season)
+        {
+            Game1.currentSeason = season switch
+            {
+                0 => "spring",
+                1 => "summer",
+                2 => "fall",
+                3 => "winter",
+                _ => Game1.currentSeason,
+            };
+            Game1.setGraphicsForSeason();
+            Game1.stats.DaysPlayed = (uint)SDate.Now().DaysSinceStart;
+            if (Game1.IsMasterGame)
+                Game1.netWorldState.Value.UpdateFromGame1();
+        }
+    }
+}

--- a/CJBCheatsMenu/Framework/Cheats/Time/SetSeasonCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/SetSeasonCheat.cs
@@ -1,13 +1,12 @@
 using System.Collections.Generic;
 using CJBCheatsMenu.Framework.Components;
-using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
 
 namespace CJBCheatsMenu.Framework.Cheats.Time
 {
     /// <summary>A cheat which sets the current season.</summary>
-    internal class SetSeasonCheat : BaseCheat
+    internal class SetSeasonCheat : BaseDateCheat
     {
         /*********
         ** Public methods
@@ -23,7 +22,7 @@ namespace CJBCheatsMenu.Framework.Cheats.Time
                 maxValue: 3,
                 setValue: this.SafelySetSeason,
                 width: 100,
-                format: value => Utility.getSeasonNameFromNumber(value)
+                format: Utility.getSeasonNameFromNumber
             );
         }
 
@@ -32,21 +31,19 @@ namespace CJBCheatsMenu.Framework.Cheats.Time
         ** Private methods
         *********/
         /// <summary>Safely transition to the given season.</summary>
-        /// <param name="season">The season.</param>
-        private void SafelySetSeason(int season)
+        /// <param name="seasonNumber">The season number.</param>
+        private void SafelySetSeason(int seasonNumber)
         {
-            Game1.currentSeason = season switch
+            string season = seasonNumber switch
             {
                 0 => "spring",
                 1 => "summer",
                 2 => "fall",
                 3 => "winter",
-                _ => Game1.currentSeason,
+                _ => Game1.currentSeason
             };
-            Game1.setGraphicsForSeason();
-            Game1.stats.DaysPlayed = (uint)SDate.Now().DaysSinceStart;
-            if (Game1.IsMasterGame)
-                Game1.netWorldState.Value.UpdateFromGame1();
+
+            this.SafelySetDate(Game1.dayOfMonth, season, Game1.year);
         }
     }
 }

--- a/CJBCheatsMenu/Framework/Cheats/Time/SetYearCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/SetYearCheat.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CJBCheatsMenu.Framework.Components;
 using StardewValley;
@@ -19,7 +20,7 @@ namespace CJBCheatsMenu.Framework.Cheats.Time
                 label: I18n.Date_Year(),
                 value: Game1.year,
                 minValue: 1,
-                maxValue: 30,
+                maxValue: Math.Max(30, Game1.year + 15),
                 setValue: this.SafelySetYear,
                 width: 100
             );

--- a/CJBCheatsMenu/Framework/Cheats/Time/SetYearCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/SetYearCheat.cs
@@ -1,13 +1,12 @@
 using System.Collections.Generic;
 using CJBCheatsMenu.Framework.Components;
-using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
 
 namespace CJBCheatsMenu.Framework.Cheats.Time
 {
     /// <summary>A cheat which sets the current year.</summary>
-    internal class SetYearCheat : BaseCheat
+    internal class SetYearCheat : BaseDateCheat
     {
         /*********
         ** Public methods
@@ -34,10 +33,7 @@ namespace CJBCheatsMenu.Framework.Cheats.Time
         /// <param name="year">The year.</param>
         private void SafelySetYear(int year)
         {
-            Game1.year = year;
-            Game1.stats.DaysPlayed = (uint)SDate.Now().DaysSinceStart;
-            if (Game1.IsMasterGame)
-                Game1.netWorldState.Value.UpdateFromGame1();
+            this.SafelySetDate(Game1.dayOfMonth, Game1.currentSeason, year);
         }
     }
 }

--- a/CJBCheatsMenu/Framework/Cheats/Time/SetYearCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Time/SetYearCheat.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using CJBCheatsMenu.Framework.Components;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+using StardewValley.Menus;
+
+namespace CJBCheatsMenu.Framework.Cheats.Time
+{
+    /// <summary>A cheat which sets the current year.</summary>
+    internal class SetYearCheat : BaseCheat
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Get the config UI fields to show in the cheats menu.</summary>
+        /// <param name="context">The cheat context.</param>
+        public override IEnumerable<OptionsElement> GetFields(CheatContext context)
+        {
+            yield return new CheatsOptionsSlider(
+                label: I18n.Date_Year(),
+                value: Game1.year,
+                minValue: 1,
+                maxValue: 30,
+                setValue: this.SafelySetYear,
+                width: 100
+            );
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Safely transition to the given year.</summary>
+        /// <param name="year">The year.</param>
+        private void SafelySetYear(int year)
+        {
+            Game1.year = year;
+            Game1.stats.DaysPlayed = (uint)SDate.Now().DaysSinceStart;
+            if (Game1.IsMasterGame)
+                Game1.netWorldState.Value.UpdateFromGame1();
+        }
+    }
+}

--- a/CJBCheatsMenu/Framework/CheatsMenu.cs
+++ b/CJBCheatsMenu/Framework/CheatsMenu.cs
@@ -489,10 +489,20 @@ namespace CJBCheatsMenu.Framework
                     break;
 
                 case MenuTab.Time:
+                    // time of day
                     this.AddOptions(
                         $"{I18n.Time_Title()}:",
                         cheats.FreezeTime,
                         cheats.SetTime
+                    );
+
+                    // date
+                    this.AddTitle($"{I18n.Date_Title()}:");
+                    this.AddDescription(I18n.Date_Warning());
+                    this.AddOptions(
+                        cheats.SetYear,
+                        cheats.SetSeason,
+                        cheats.SetDay
                     );
                     break;
 

--- a/CJBCheatsMenu/Framework/CheatsMenu.cs
+++ b/CJBCheatsMenu/Framework/CheatsMenu.cs
@@ -500,9 +500,9 @@ namespace CJBCheatsMenu.Framework
                     this.AddTitle($"{I18n.Date_Title()}:");
                     this.AddDescription(I18n.Date_Warning());
                     this.AddOptions(
-                        cheats.SetYear,
+                        cheats.SetDay,
                         cheats.SetSeason,
-                        cheats.SetDay
+                        cheats.SetYear
                     );
                     break;
 

--- a/CJBCheatsMenu/Framework/I18n.cs
+++ b/CJBCheatsMenu/Framework/I18n.cs
@@ -70,7 +70,7 @@ namespace CJBCheatsMenu.Framework
             return I18n.GetByKey("tabs.warp");
         }
 
-        /// <summary>Get a translation equivalent to "Time".</summary>
+        /// <summary>Get a translation equivalent to "Time &amp; Date".</summary>
         public static string Tabs_Time()
         {
             return I18n.GetByKey("tabs.time");
@@ -844,6 +844,36 @@ namespace CJBCheatsMenu.Framework
         public static string Time_TimeFrozenMessage()
         {
             return I18n.GetByKey("time.time-frozen-message");
+        }
+
+        /// <summary>Get a translation equivalent to "Date".</summary>
+        public static string Date_Title()
+        {
+            return I18n.GetByKey("date.title");
+        }
+
+        /// <summary>Get a translation equivalent to "Use this section at your own risk!\nMany updates will not occur until a night has passed.".</summary>
+        public static string Date_Warning()
+        {
+            return I18n.GetByKey("date.warning");
+        }
+
+        /// <summary>Get a translation equivalent to "Year".</summary>
+        public static string Date_Year()
+        {
+            return I18n.GetByKey("date.year");
+        }
+
+        /// <summary>Get a translation equivalent to "Season".</summary>
+        public static string Date_Season()
+        {
+            return I18n.GetByKey("date.season");
+        }
+
+        /// <summary>Get a translation equivalent to "Day".</summary>
+        public static string Date_Day()
+        {
+            return I18n.GetByKey("date.day");
         }
 
         /// <summary>Get a translation equivalent to "Use this section at your own risk!\nThis may cause issues like skipped mail, events, or quests.".</summary>

--- a/CJBCheatsMenu/Framework/I18n.cs
+++ b/CJBCheatsMenu/Framework/I18n.cs
@@ -70,7 +70,7 @@ namespace CJBCheatsMenu.Framework
             return I18n.GetByKey("tabs.warp");
         }
 
-        /// <summary>Get a translation equivalent to "Time &amp; Date".</summary>
+        /// <summary>Get a translation equivalent to "Time".</summary>
         public static string Tabs_Time()
         {
             return I18n.GetByKey("tabs.time");

--- a/CJBCheatsMenu/Framework/I18n.cs
+++ b/CJBCheatsMenu/Framework/I18n.cs
@@ -852,7 +852,7 @@ namespace CJBCheatsMenu.Framework
             return I18n.GetByKey("date.title");
         }
 
-        /// <summary>Get a translation equivalent to "Use this section at your own risk!\nMany updates will not occur until a night has passed.".</summary>
+        /// <summary>Get a translation equivalent to "Some things won't update until a night has passed.".</summary>
         public static string Date_Warning()
         {
             return I18n.GetByKey("date.warning");

--- a/CJBCheatsMenu/Framework/MenuTab.cs
+++ b/CJBCheatsMenu/Framework/MenuTab.cs
@@ -21,7 +21,7 @@ namespace CJBCheatsMenu.Framework
         /// <summary>The 'warp locations' tab.</summary>
         WarpLocations,
 
-        /// <summary>The 'time' tab.</summary>
+        /// <summary>The 'time &amp; date' tab.</summary>
         Time,
 
         /// <summary>The 'advanced' tab.</summary>

--- a/CJBCheatsMenu/Framework/MenuTab.cs
+++ b/CJBCheatsMenu/Framework/MenuTab.cs
@@ -21,7 +21,7 @@ namespace CJBCheatsMenu.Framework
         /// <summary>The 'warp locations' tab.</summary>
         WarpLocations,
 
-        /// <summary>The 'time &amp; date' tab.</summary>
+        /// <summary>The 'time' tab.</summary>
         Time,
 
         /// <summary>The 'advanced' tab.</summary>

--- a/CJBCheatsMenu/i18n/de.json
+++ b/CJBCheatsMenu/i18n/de.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Wetter",
     "tabs.relationships": "Beziehungen",
     "tabs.warp": "Teleportieren",
-    "tabs.time": "Zeit",
+    "tabs.time": "Zeit", // TODO: "Time & Date"
     "tabs.advanced": "Erweitert",
     "tabs.controls": "Steuerung",
 
@@ -194,14 +194,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    //time
     "time.title": "Zeit",
     "time.freeze-inside": "Zeit in Gebäuden stoppen",
     "time.freeze-caves": "Zeit in Höhlen stoppen",
     "time.freeze-everywhere": "Zeit überall stoppen",
     "time.time": "Zeit",
     "time.time-frozen-message": "Zeit gestoppt",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/de.json
+++ b/CJBCheatsMenu/i18n/de.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Wetter",
     "tabs.relationships": "Beziehungen",
     "tabs.warp": "Teleportieren",
-    "tabs.time": "Zeit", // TODO: "Time & Date"
+    "tabs.time": "Zeit",
     "tabs.advanced": "Erweitert",
     "tabs.controls": "Steuerung",
 
@@ -194,7 +194,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     //time
     "time.title": "Zeit",
@@ -205,11 +205,12 @@
     "time.time-frozen-message": "Zeit gestoppt",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/de.json
+++ b/CJBCheatsMenu/i18n/de.json
@@ -207,7 +207,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/default.json
+++ b/CJBCheatsMenu/i18n/default.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Weather",
     "tabs.relationships": "Relationships",
     "tabs.warp": "Warp Locations",
-    "tabs.time": "Time & Date",
+    "tabs.time": "Time",
     "tabs.advanced": "Advanced",
     "tabs.controls": "Controls",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Time",

--- a/CJBCheatsMenu/i18n/default.json
+++ b/CJBCheatsMenu/i18n/default.json
@@ -205,7 +205,7 @@
 
     // date
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/default.json
+++ b/CJBCheatsMenu/i18n/default.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Weather",
     "tabs.relationships": "Relationships",
     "tabs.warp": "Warp Locations",
-    "tabs.time": "Time",
+    "tabs.time": "Time & Date",
     "tabs.advanced": "Advanced",
     "tabs.controls": "Controls",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Time",
     "time.freeze-inside": "Freeze Time Inside",
     "time.freeze-caves": "Freeze Time In Caves",
     "time.freeze-everywhere": "Freeze Time Everywhere",
     "time.time": "Time",
     "time.time-frozen-message": "Time Frozen",
+
+    // date
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/es.json
+++ b/CJBCheatsMenu/i18n/es.json
@@ -205,7 +205,7 @@
 
     // date
     "date.title": "Fecha",
-    "date.warning": "Utiliza esta sección bajo tu propio riesgo!\nMuchas actualizaciones no pasarán hasta que haya pasado una noche.",
+    "date.warning": "Muchas actualizaciones no pasarán hasta que haya pasado una noche.",
     "date.year": "Año",
     "date.season": "Estación",
     "date.day": "Día",

--- a/CJBCheatsMenu/i18n/es.json
+++ b/CJBCheatsMenu/i18n/es.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Clima",
     "tabs.relationships": "Relaciones",
     "tabs.warp": "Puntos de Teletransporte",
-    "tabs.time": "Tiempo",
+    "tabs.time": "Tiempo & Fecha",
     "tabs.advanced": "Opciones Avanzadas",
     "tabs.controls": "Controles",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Tiempo",
     "time.freeze-inside": "Parar el Tiempo Dentro",
     "time.freeze-caves": "Parar el Tiempo en Cuevas",
     "time.freeze-everywhere": "Parar el Tiempo en Todas Partes",
     "time.time": "Tiempo",
     "time.time-frozen-message": "Tiempo Parado",
+
+    // date
+    "date.title": "Fecha",
+    "date.warning": "Utiliza esta sección bajo tu propio riesgo!\nMuchas actualizaciones no pasarán hasta que haya pasado una noche.",
+    "date.year": "Año",
+    "date.season": "Estación",
+    "date.day": "Día",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/es.json
+++ b/CJBCheatsMenu/i18n/es.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Clima",
     "tabs.relationships": "Relaciones",
     "tabs.warp": "Puntos de Teletransporte",
-    "tabs.time": "Tiempo & Fecha",
+    "tabs.time": "Tiempo",
     "tabs.advanced": "Opciones Avanzadas",
     "tabs.controls": "Controles",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Tiempo",

--- a/CJBCheatsMenu/i18n/fr.json
+++ b/CJBCheatsMenu/i18n/fr.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Météo",
     "tabs.relationships": "Social",
     "tabs.warp": "Téléportation",
-    "tabs.time": "Temps",
+    "tabs.time": "Temps", // TODO: "Time & Date"
     "tabs.advanced": "Avancé",
     "tabs.controls": "Contrôles",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Temps",
     "time.freeze-inside": "Arrêter le temps à l'intérieur",
     "time.freeze-caves": "Arrêter le temps dans les grottes",
     "time.freeze-everywhere": "Arrêter le temps partout",
     "time.time": "Heure",
     "time.time-frozen-message": "Temps figé",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/fr.json
+++ b/CJBCheatsMenu/i18n/fr.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Météo",
     "tabs.relationships": "Social",
     "tabs.warp": "Téléportation",
-    "tabs.time": "Temps", // TODO: "Time & Date"
+    "tabs.time": "Temps",
     "tabs.advanced": "Avancé",
     "tabs.controls": "Contrôles",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Temps",
@@ -204,11 +204,12 @@
     "time.time-frozen-message": "Temps figé",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/fr.json
+++ b/CJBCheatsMenu/i18n/fr.json
@@ -206,7 +206,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/hu.json
+++ b/CJBCheatsMenu/i18n/hu.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Időjárás",
     "tabs.relationships": "Kapcsolatok",
     "tabs.warp": "Teleport",
-    "tabs.time": "Idő", // TODO: "Time & Date"
+    "tabs.time": "Idő",
     "tabs.advanced": "Haladó",
     "tabs.controls": "Irányítás",
 
@@ -194,7 +194,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Idő",
@@ -205,11 +205,12 @@
     "time.time-frozen-message": "Idő Megállítva",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/hu.json
+++ b/CJBCheatsMenu/i18n/hu.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Időjárás",
     "tabs.relationships": "Kapcsolatok",
     "tabs.warp": "Teleport",
-    "tabs.time": "Idő",
+    "tabs.time": "Idő", // TODO: "Time & Date"
     "tabs.advanced": "Haladó",
     "tabs.controls": "Irányítás",
 
@@ -194,14 +194,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Idő",
     "time.freeze-inside": "Idő Megállítása Beltéren",
     "time.freeze-caves": "Idő Megállítása Barlangokban",
     "time.freeze-everywhere": "Idő Megállítása Mindenhol",
     "time.time": "Idő",
     "time.time-frozen-message": "Idő Megállítva",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/hu.json
+++ b/CJBCheatsMenu/i18n/hu.json
@@ -207,7 +207,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/it.json
+++ b/CJBCheatsMenu/i18n/it.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Meteo",
     "tabs.relationships": "Relazioni",
     "tabs.warp": "Luoghi Teletrasporto",
-    "tabs.time": "Tempo",
+    "tabs.time": "Tempo", // TODO: "Time & Date"
     "tabs.advanced": "Avanzate",
     "tabs.controls": "Controlli",
 
@@ -194,14 +194,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Tempo",
     "time.freeze-inside": "Ferma il Tempo all'Interno",
     "time.freeze-caves": "Ferma il Tempo nelle Grotte",
     "time.freeze-everywhere": "Ferma il Tempo Ovunque",
     "time.time": "Tempo",
     "time.time-frozen-message": "Ferma l'Orologio",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/it.json
+++ b/CJBCheatsMenu/i18n/it.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Meteo",
     "tabs.relationships": "Relazioni",
     "tabs.warp": "Luoghi Teletrasporto",
-    "tabs.time": "Tempo", // TODO: "Time & Date"
+    "tabs.time": "Tempo",
     "tabs.advanced": "Avanzate",
     "tabs.controls": "Controlli",
 
@@ -194,7 +194,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Tempo",
@@ -205,11 +205,12 @@
     "time.time-frozen-message": "Ferma l'Orologio",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/it.json
+++ b/CJBCheatsMenu/i18n/it.json
@@ -207,7 +207,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/ja.json
+++ b/CJBCheatsMenu/i18n/ja.json
@@ -12,7 +12,7 @@
     "tabs.weather": "天気",
     "tabs.relationships": "人間関係",
     "tabs.warp": "ワープ",
-    "tabs.time": "時間",
+    "tabs.time": "時間", // TODO: "Time & Date"
     "tabs.advanced": "上級者向け",
     "tabs.controls": "キー変更",
 
@@ -194,14 +194,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "時間停止",
     "time.freeze-inside": "屋内で時間が止まる",
     "time.freeze-caves": "洞窟の中で時間が止まる",
     "time.freeze-everywhere": "どこでも時間が止まる",
     "time.time": "時間",
     "time.time-frozen-message": "時間停止！",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/ja.json
+++ b/CJBCheatsMenu/i18n/ja.json
@@ -12,7 +12,7 @@
     "tabs.weather": "天気",
     "tabs.relationships": "人間関係",
     "tabs.warp": "ワープ",
-    "tabs.time": "時間", // TODO: "Time & Date"
+    "tabs.time": "時間",
     "tabs.advanced": "上級者向け",
     "tabs.controls": "キー変更",
 
@@ -194,7 +194,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "時間停止",
@@ -205,11 +205,12 @@
     "time.time-frozen-message": "時間停止！",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/ja.json
+++ b/CJBCheatsMenu/i18n/ja.json
@@ -207,7 +207,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/ko.json
+++ b/CJBCheatsMenu/i18n/ko.json
@@ -12,7 +12,7 @@
     "tabs.weather": "날씨",
     "tabs.relationships": "사회관계",
     "tabs.warp": "이동",
-    "tabs.time": "시간", // TODO: "Time & Date"
+    "tabs.time": "시간",
     "tabs.advanced": "고급",
     "tabs.controls": "조작키",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "시간",
@@ -204,11 +204,12 @@
     "time.time-frozen-message": "시간 멈춤",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/ko.json
+++ b/CJBCheatsMenu/i18n/ko.json
@@ -12,7 +12,7 @@
     "tabs.weather": "날씨",
     "tabs.relationships": "사회관계",
     "tabs.warp": "이동",
-    "tabs.time": "시간",
+    "tabs.time": "시간", // TODO: "Time & Date"
     "tabs.advanced": "고급",
     "tabs.controls": "조작키",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "시간",
     "time.freeze-inside": "실내에서 시간 정지",
     "time.freeze-caves": "광산/해골동굴 안에서 시간 정지",
     "time.freeze-everywhere": "모든 장소에서 시간 정지",
     "time.time": "시간",
     "time.time-frozen-message": "시간 멈춤",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/ko.json
+++ b/CJBCheatsMenu/i18n/ko.json
@@ -206,7 +206,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/pt.json
+++ b/CJBCheatsMenu/i18n/pt.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Tempo",
     "tabs.relationships": "Relacionamentos",
     "tabs.warp": "Teletransporte",
-    "tabs.time": "Horário",
+    "tabs.time": "Horário", // TODO: "Time & Date"
     "tabs.advanced": "Avançado",
     "tabs.controls": "Controles",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Horário",
     "time.freeze-inside": "Parar o tempo dentro das construções",
     "time.freeze-caves": "Parar o tempo nas cavernas",
     "time.freeze-everywhere": "Parar o tempo em qualquer lugar",
     "time.time": "Horário",
     "time.time-frozen-message": "Tempo parado",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/pt.json
+++ b/CJBCheatsMenu/i18n/pt.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Tempo",
     "tabs.relationships": "Relacionamentos",
     "tabs.warp": "Teletransporte",
-    "tabs.time": "Horário", // TODO: "Time & Date"
+    "tabs.time": "Horário",
     "tabs.advanced": "Avançado",
     "tabs.controls": "Controles",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Horário",
@@ -204,11 +204,12 @@
     "time.time-frozen-message": "Tempo parado",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/pt.json
+++ b/CJBCheatsMenu/i18n/pt.json
@@ -206,7 +206,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/ru.json
+++ b/CJBCheatsMenu/i18n/ru.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Погода",
     "tabs.relationships": "Отношения",
     "tabs.warp": "Телепортация",
-    "tabs.time": "Время", // TODO: "Time & Date"
+    "tabs.time": "Время",
     "tabs.advanced": "Прочее",
     "tabs.controls": "Управление",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Время",
@@ -204,11 +204,12 @@
     "time.time-frozen-message": "Время остановлено",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/ru.json
+++ b/CJBCheatsMenu/i18n/ru.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Погода",
     "tabs.relationships": "Отношения",
     "tabs.warp": "Телепортация",
-    "tabs.time": "Время",
+    "tabs.time": "Время", // TODO: "Time & Date"
     "tabs.advanced": "Прочее",
     "tabs.controls": "Управление",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Время",
     "time.freeze-inside": "Остановить время в помещениях",
     "time.freeze-caves": "Остановить время в пещерах",
     "time.freeze-everywhere": "Остановить время в любых местах",
     "time.time": "Текущее время",
     "time.time-frozen-message": "Время остановлено",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/ru.json
+++ b/CJBCheatsMenu/i18n/ru.json
@@ -206,7 +206,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/tr.json
+++ b/CJBCheatsMenu/i18n/tr.json
@@ -206,7 +206,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/tr.json
+++ b/CJBCheatsMenu/i18n/tr.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Hava Durumu",
     "tabs.relationships": "İlişkiler",
     "tabs.warp": "Işınlanma",
-    "tabs.time": "Zaman", // TODO: "Time & Date"
+    "tabs.time": "Zaman",
     "tabs.advanced": "Gelişmiş",
     "tabs.controls": "Kontroller",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "Zaman",
@@ -204,11 +204,12 @@
     "time.time-frozen-message": "Zaman Dondu",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/tr.json
+++ b/CJBCheatsMenu/i18n/tr.json
@@ -12,7 +12,7 @@
     "tabs.weather": "Hava Durumu",
     "tabs.relationships": "İlişkiler",
     "tabs.warp": "Işınlanma",
-    "tabs.time": "Zaman",
+    "tabs.time": "Zaman", // TODO: "Time & Date"
     "tabs.advanced": "Gelişmiş",
     "tabs.controls": "Kontroller",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "Zaman",
     "time.freeze-inside": "İçerideyken Zamanı Dondur",
     "time.freeze-caves": "Mağaradayken Zamanı Dondur",
     "time.freeze-everywhere": "Zamanı Her Yerde Dondur",
     "time.time": "Saat",
     "time.time-frozen-message": "Zaman Dondu",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********

--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -12,7 +12,7 @@
     "tabs.weather": "天气",
     "tabs.relationships": "人际关系",
     "tabs.warp": "传送",
-    "tabs.time": "时间", // TODO: "Time & Date"
+    "tabs.time": "时间",
     "tabs.advanced": "高级",
     "tabs.controls": "控制",
 
@@ -193,7 +193,7 @@
 
 
     /*********
-    ** Time & Date tab
+    ** Time tab
     *********/
     // time
     "time.title": "时间",
@@ -204,11 +204,12 @@
     "time.time-frozen-message": "时间冻结",
 
     // date
-    "date.title": "Date", // TODO
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
-    "date.year": "Year", // TODO
-    "date.season": "Season", // TODO
-    "date.day": "Day", // TODO
+    // TODO
+    "date.title": "Date",
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.year": "Year",
+    "date.season": "Season",
+    "date.day": "Day",
 
 
     /*********

--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -206,7 +206,7 @@
     // date
     // TODO
     "date.title": "Date",
-    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.",
+    "date.warning": "Some things won't update until a night has passed.",
     "date.year": "Year",
     "date.season": "Season",
     "date.day": "Day",

--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -12,7 +12,7 @@
     "tabs.weather": "天气",
     "tabs.relationships": "人际关系",
     "tabs.warp": "传送",
-    "tabs.time": "时间",
+    "tabs.time": "时间", // TODO: "Time & Date"
     "tabs.advanced": "高级",
     "tabs.controls": "控制",
 
@@ -193,14 +193,22 @@
 
 
     /*********
-    ** Time tab
+    ** Time & Date tab
     *********/
+    // time
     "time.title": "时间",
     "time.freeze-inside": "在建筑内冻结时间",
     "time.freeze-caves": "在矿井内冻结时间",
     "time.freeze-everywhere": "任何地方都冻结时间",
     "time.time": "时间",
     "time.time-frozen-message": "时间冻结",
+
+    // date
+    "date.title": "Date", // TODO
+    "date.warning": "Use this section at your own risk!\nMany updates will not occur until a night has passed.", // TODO
+    "date.year": "Year", // TODO
+    "date.season": "Season", // TODO
+    "date.day": "Day", // TODO
 
 
     /*********


### PR DESCRIPTION
The calendar is now at our fingertips graphically.

Renames the tab from "Time" to "Time & Date" but keeps the namespace and other code names as `Time`/`time`.

The year cheat ranges from 1 to 30 to make the slider reasonably controllable. That does leave the edge case of extremely long plays.

Calling `Game1.netWorldState.Value.UpdateFromGame1` is a new measure compared to the corresponding SMAPI commands. It is required to bring `Game1.Date` (which derives from the `netWorldState`) in alignment with the simple fields on `Game1`. Since `Game1.Date` is increasingly used in the code, it seems appropriate to sync it. If this works for you, I can submit a PR for SMAPI to do the same in the `world_set*` console commands.