### PR TITLE
Replace slingshot ID check with type field check

### DIFF
--- a/CJBItemSpawner/Framework/ItemData/ItemRepository.cs
+++ b/CJBItemSpawner/Framework/ItemData/ItemRepository.cs
@@ -107,7 +107,7 @@ namespace CJBItemSpawner.Framework.ItemData
                     var weaponsData = this.TryLoad<int, string>("Data\\weapons");
                     foreach (int id in weaponsData.Keys)
                     {
-                        yield return this.TryCreate(ItemType.Weapon, id, p => weaponsData[p.ID].Split('/')[8] == '4'
+                        yield return this.TryCreate(ItemType.Weapon, id, p => weaponsData[p.ID].Split('/')[8] == "4"
                             ? new Slingshot(p.ID)
                             : new MeleeWeapon(p.ID)
                         );

--- a/CJBItemSpawner/Framework/ItemData/ItemRepository.cs
+++ b/CJBItemSpawner/Framework/ItemData/ItemRepository.cs
@@ -104,9 +104,10 @@ namespace CJBItemSpawner.Framework.ItemData
                 // weapons
                 if (ShouldGet(ItemType.Weapon))
                 {
-                    foreach (int id in this.TryLoad<int, string>("Data\\weapons").Keys)
+                    var weaponsData = this.TryLoad<int, string>("Data\\weapons");
+                    foreach (int id in weaponsData.Keys)
                     {
-                        yield return this.TryCreate(ItemType.Weapon, id, p => p.ID is >= 32 and <= 34
+                        yield return this.TryCreate(ItemType.Weapon, id, p => weaponsData[p.ID].Split('/')[8] == '4'
                             ? new Slingshot(p.ID)
                             : new MeleeWeapon(p.ID)
                         );


### PR DESCRIPTION
The current implementation checks for slingshots by the ID's of vanilla slingshots, which fails to consider that mods may add custom slingshots. Meanwhile the slingshot weapon type is sitting unused inside "Data/weapons".