### PR TITLE
Update Chinese translations for CJB Cheats Menu and CJB Item Spawner

### DIFF
--- a/CJBCheatsMenu/i18n/zh.json
+++ b/CJBCheatsMenu/i18n/zh.json
@@ -56,7 +56,7 @@
     "farm.instant-build": "农场建筑立即完成",
     "farm.auto-feed-animals": "自动喂食动物",
     "farm.auto-pet-animals": "自动抚摸动物",
-    "farm.auto-pet-pets": "Auto-Pet Pets", // TODO
+    "farm.auto-pet-pets": "自动抚摸宠物",
     "farm.infinite-hay": "无限干草",
 
     // fishing

--- a/CJBItemSpawner/i18n/zh.json
+++ b/CJBItemSpawner/i18n/zh.json
@@ -3,7 +3,7 @@
     ** Sort button
     *********/
     "sort.by-name": "按名称排序",
-    "sort.by-price": "Sell Price", // TODO
+    "sort.by-price": "出售价格",
     "sort.by-type": "按类型排序",
     "sort.by-id": "按ID排序",
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ on the wiki for help contributing translations.
 
 &nbsp;      | CJB Cheats Menu                 | CJB Item Spawner                 | CJB Show Item Sell Price
 :---------- | :------------------------------ | :------------------------------- | :-------------------------------------
-Chinese     | [↻](CJBCheatsMenu/i18n/zh.json) | [↻](CJBItemSpawner/i18n/zh.json) | [✓](CJBShowItemSellPrice/i18n/zh.json)
+Chinese     | [✓](CJBCheatsMenu/i18n/zh.json) | [✓](CJBItemSpawner/i18n/zh.json) | [✓](CJBShowItemSellPrice/i18n/zh.json)
 French      | [✓](CJBCheatsMenu/i18n/fr.json) | [✓](CJBItemSpawner/i18n/fr.json) | [✓](CJBShowItemSellPrice/i18n/fr.json)
 German      | [↻](CJBCheatsMenu/i18n/de.json) | [↻](CJBItemSpawner/i18n/de.json) | [✓](CJBShowItemSellPrice/i18n/de.json)
 Hungarian   | [↻](CJBCheatsMenu/i18n/hu.json) | [↻](CJBItemSpawner/i18n/hu.json) | [✓](CJBShowItemSellPrice/i18n/hu.json)


### PR DESCRIPTION
Update the Chinese translation in bothCBJCheatsMune and CJBItemSpawner. Right now the Chinese translation should be full, and the Chinese row in "language support table" on redme can be changed from "↻" to "✓".