### PR TITLE
Fix net field build warning in infinite hay cheat

### DIFF
--- a/CJBCheatsMenu/Framework/Cheats/FarmAndFishing/InfiniteHayCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/FarmAndFishing/InfiniteHayCheat.cs
@@ -49,7 +49,7 @@ namespace CJBCheatsMenu.Framework.Cheats.FarmAndFishing
                 {
                     if (location.buildings.Count > 0)
                     {
-                        int addHay = location.GetHayCapacity() - location.piecesOfHay;
+                        int addHay = location.GetHayCapacity() - location.piecesOfHay.Value;
                         location.tryToAddHay(addHay);
                     }
 


### PR DESCRIPTION
Fixes the following compiler warnings in `InfiniteHayCheat.cs`

 -  `InfiniteHayCheat.cs(52, 66): [CS0618] 'NetInt.implicit operator int(NetInt)' is obsolete: 'Implicitly casting NetInt to int can have unintuitive behavior. Use the Value field instead.'`

 -  `InfiniteHayCheat.cs(52, 66): [AvoidImplicitNetFieldCast] This implicitly converts 'location.piecesOfHay' from NetInt to int, but NetInt has unintuitive implicit conversion rules. Consider comparing against the actual value instead to avoid bugs. See https://smapi.io/package/avoid-implicit-net-field-cast for details. (https://smapi.io/package/avoid-implicit-net-field-cast)`

My building/testing environment giving this warning is: Jetbrains Rider 2022.2.4, .NET SDK 8.0.203, MSBuild 17.0, Stardew Valley 1.6.3, SMAPI 4.0.4

Obviously this is nothing serious, fixed it locally because it forced Rider out of the build output log view into a view just showing those two warnings on every build, figured I'd send it upstream.