### PR TITLE
Add cheat to toggle perfection achieved

### DIFF
--- a/CJBCheatsMenu/Framework/Cheats/Advanced/UnlockContentCheat.cs
+++ b/CJBCheatsMenu/Framework/Cheats/Advanced/UnlockContentCheat.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using CJBCheatsMenu.Framework.Components;
+using StardewValley;
 using StardewValley.Menus;
 
 namespace CJBCheatsMenu.Framework.Cheats.Advanced
@@ -24,6 +25,24 @@ namespace CJBCheatsMenu.Framework.Cheats.Advanced
                 value: this.HasFlag("canReadJunimoText"),
                 setValue: value => this.SetFlag(value, "canReadJunimoText")
             );
+            yield return new CheatsOptionsCheckbox(
+                label: I18n.Flags_UnlockedContent_Perfection(),
+                value: Game1.player.team.farmPerfect.Value,
+                setValue: value => this.SetPerfection(value)
+            );
+        }
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Sets the player's perfection status.</summary>
+        /// <param name="achieved">Whether to enable or disable perfection.</param>
+        private void SetPerfection(bool achieved)
+        {
+            Game1.player.team.farmPerfect.Value = achieved;
+            this.SetFlag(achieved, "Farm_Eternal");
+            this.SetFlag(achieved, "SummitBoulder");
+            this.SetFlag(false, "Summit_event");
         }
     }
 }

--- a/CJBCheatsMenu/i18n/default.json
+++ b/CJBCheatsMenu/i18n/default.json
@@ -229,6 +229,7 @@
     "flags.unlocked-content": "Unlocked content",
     "flags.unlocked-content.dyes-and-tailoring": "Dyes & tailoring",
     "flags.unlocked-content.junimo-text": "Can read Junimo text",
+    "flags.unlocked-content.perfection": "Perfection achieved",
     "flags.community-center": "Community Center",
     "flags.community-center.door-unlocked": "Door Unlocked",
     "flags.jojamart.membership": "JojaMart Membership",


### PR DESCRIPTION
Added a perfection achieved toggle under the UnlockContentCheat section.
This is mainly to get around the new QI 'cursed' cutscene added in 1.6, when I was trying to test a mod that edited the summit cutscene.

Also, I can see why this feature might not be entirely wanted, perfection is a test of time and resilience after all - so feel free to close the PR if you feel the addition unsuitable!