### PR TITLE
Item Spawner API (Variants)

### DIFF
--- a/CJBItemSpawner/Framework/ItemData/ItemRepository.cs
+++ b/CJBItemSpawner/Framework/ItemData/ItemRepository.cs
@@ -16,8 +16,19 @@ namespace CJBItemSpawner.Framework.ItemData;
 internal class ItemRepository
 {
     /*********
+    ** Fields
+    *********/
+    /// <summary>Used to communicate with other mods</summary>
+    private readonly ItemSpawnerAPI API;
+
+    /*********
     ** Public methods
     *********/
+    public ItemRepository(ItemSpawnerAPI API)
+    {
+        this.API = API;
+    }
+
     /// <summary>Get all spawnable items.</summary>
     /// <param name="onlyType">Only include items for the given <see cref="IItemDataDefinition.Identifier"/>.</param>
     /// <param name="includeVariants">Whether to include flavored variants like "Sunflower Honey".</param>
@@ -90,7 +101,8 @@ internal class ItemRepository
                                             break;
 
                                         default:
-                                            if (result != null)
+                                            // skip blacklisted items
+                                            if (result != null && !this.API.IsBlacklisted(result.QualifiedItemId))
                                                 yield return result;
                                             break;
                                     }
@@ -98,6 +110,9 @@ internal class ItemRepository
                                     if (includeVariants)
                                     {
                                         foreach (SearchableItem? variant in this.GetFlavoredObjectVariants(objectDataDefinition, result?.Item as SObject, itemType))
+                                            yield return variant;
+
+                                        foreach (SearchableItem? variant in this.API.GetVariantsFor("(O)", id, this.TryCreate))
                                             yield return variant;
                                     }
                                 }
@@ -108,7 +123,17 @@ internal class ItemRepository
                     // no special handling needed
                     default:
                         foreach (string id in itemType.GetAllIds())
-                            yield return this.TryCreate(itemType.Identifier, id, p => ItemRegistry.Create(itemType.Identifier + p.Id));
+                        {
+                            // skip blacklisted items
+                            if (!this.API.IsBlacklisted(itemType.Identifier + id))
+                                yield return this.TryCreate(itemType.Identifier, id, p => ItemRegistry.Create(itemType.Identifier + p.Id));
+
+                            if (includeVariants)
+                            {
+                                foreach (SearchableItem? variant in this.API.GetVariantsFor(itemType.Identifier, id, this.TryCreate))
+                                    yield return variant;
+                            }
+                        }
                         break;
                 }
             }

--- a/CJBItemSpawner/Framework/ItemSpawnerAPI.cs
+++ b/CJBItemSpawner/Framework/ItemSpawnerAPI.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using CJBItemSpawner.Framework.ItemData;
+using StardewValley;
+
+namespace CJBItemSpawner.Framework
+{
+    public class ItemSpawnerAPI : IItemSpawnerAPI
+    {
+        internal delegate SearchableItem? SearchableItemFactory(string type, string key, Func<SearchableItem, Item> createItem);
+
+        private readonly HashSet<string> Blacklist = [];
+
+        public class VariantsRequestedEventArgs : IItemSpawnerAPI.IVariantsRequestedEventArgs
+        {
+            private readonly SearchableItemFactory TryCreate;
+            private readonly string type;
+            internal readonly List<SearchableItem> Items = [];
+
+            /// <inheritdoc/>
+            public string BaseId { get; init; }
+
+            /// <inheritdoc/>
+            public void TryAddVariant(string variantId, Func<object, Item> createItem)
+            {
+                if (this.TryCreate(this.type,variantId, createItem) is SearchableItem result)
+                    this.Items.Add(result);
+            }
+
+            internal VariantsRequestedEventArgs(string type, string baseId, SearchableItemFactory tryCreate)
+            {
+                this.BaseId = baseId;
+                this.TryCreate = tryCreate;
+                this.type = type;
+            }
+        }
+
+        /// <inheritdoc/>
+        public event EventHandler<IItemSpawnerAPI.IVariantsRequestedEventArgs>? VariantsRequested;
+
+        /// <inheritdoc/>
+        public void BlacklistItem(string qualifiedId)
+        {
+            this.Blacklist.Add(qualifiedId);
+        }
+
+        /// <summary>Gets API-Added variants for a given item.</summary>
+        /// <param name="type">The item type</param>
+        /// <param name="baseId">The item's unqualified id</param>
+        internal IEnumerable<SearchableItem> GetVariantsFor(string type, string baseId, SearchableItemFactory TryCreate)
+        {
+            // skip setup and teardown if nobody is using the api.
+            if (VariantsRequested is null)
+                return [];
+
+            VariantsRequestedEventArgs args = new(type, baseId, TryCreate);
+            VariantsRequested(this, args);
+            return args.Items;
+        }
+
+        /// <summary>Gets whether or not an item has been blacklisted.</summary>
+        /// <param name="id">The qualified id for the item</param>
+        internal bool IsBlacklisted(string id)
+        {
+            return this.Blacklist.Contains(id);
+        }
+    }
+}

--- a/CJBItemSpawner/IItemSpawnerAPI.cs
+++ b/CJBItemSpawner/IItemSpawnerAPI.cs
@@ -1,0 +1,32 @@
+using System;
+using StardewValley;
+
+namespace CJBItemSpawner
+{
+    public interface IItemSpawnerAPI
+    {
+        public interface IVariantsRequestedEventArgs
+        {
+            /// <summary>The item to provide variants for</summary>
+            public string BaseId { get; }
+
+            /// <summary>Add an item variant if valid</summary>
+            /// <param name="variantId">A unique variant identifier. Should include the base item id.</param>
+            /// <param name="createItem">Creates an instance of the item</param>
+            public void TryAddVariant(string variantId, Func<object, Item> createItem);
+        }
+
+        /// <summary>
+        /// Prevent an item from being displayed in the item spawner.
+        /// Should only be used for placeholder items. <br/>
+        /// Does not disable variants for this item.
+        /// </summary>
+        /// <param name="qualifiedId">The qualified item id</param>
+        public void BlacklistItem(string qualifiedId);
+
+        /// <summary>
+        /// Can be used to add custom variants to an existing item.
+        /// </summary>
+        public event EventHandler<IVariantsRequestedEventArgs>? VariantsRequested;
+    }
+}

--- a/CJBItemSpawner/ModEntry.cs
+++ b/CJBItemSpawner/ModEntry.cs
@@ -29,6 +29,9 @@ internal class ModEntry : Mod
     /// <summary>Manages the gamepad text entry UI.</summary>
     private readonly TextEntryManager TextEntryManager = new();
 
+    /// <summary>The API</summary>
+    private readonly ItemSpawnerAPI API = new();
+
 
     /*********
     ** Public methods
@@ -65,6 +68,11 @@ internal class ModEntry : Mod
         helper.Events.GameLoop.UpdateTicked += this.OnUpdateTicked;
     }
 
+    /// <inheritdoc/>
+    public override object? GetApi()
+    {
+        return this.API;
+    }
 
     /*********
     ** Private methods
@@ -122,7 +130,7 @@ internal class ModEntry : Mod
     /// <summary>Get the items which can be spawned.</summary>
     private IEnumerable<SpawnableItem> GetSpawnableItems()
     {
-        foreach (SearchableItem entry in new ItemRepository().GetAll())
+        foreach (SearchableItem entry in new ItemRepository(this.API).GetAll())
         {
             ModDataCategory? category = this.Categories.FirstOrDefault(rule => rule.IsMatch(entry));
 


### PR DESCRIPTION
A proposed API implementation for Item Spawner. Alternative implementation to #234 and #236 that uses an event-based API to allow adding variants only.

Features:
- Allows blacklisting placeholder items
- Allows generating custom variants for items

Tested working with a real-world example in [Profession Books](https://github.com/tlitookilakin/ProfessionBooks/commit/974743af84db742fb80725b8220dc83474839b2d)