### PR TITLE
Fix inconsistent floor button width 

### DIFF
--- a/CJBCheatsMenu/Framework/Components/CheatsOptionsNumberWheel.cs
+++ b/CJBCheatsMenu/Framework/Components/CheatsOptionsNumberWheel.cs
@@ -126,7 +126,7 @@ internal class CheatsOptionsNumberWheel : CheatsOptionsButton<CheatsOptionsNumbe
         xOffset += this.MinusButtonSource.Width + 2;
 
         // get the maximum width the value label can be
-        Vector2 valueSize = Game1.dialogueFont.MeasureString(new string('0', this.FormatValue(this.Value).Length));
+        Vector2 valueSize = Game1.dialogueFont.MeasureString("000");
         int maxValueWidth = (int)(valueSize.X / Game1.pixelZoom) + 1;
         int maxValueHeight = (int)valueSize.Y;
 


### PR DESCRIPTION
A shift in the location of the increase floor button allows for easier rapid clicking or shift clicking on the button so that it does not move around.